### PR TITLE
fix bugs, see PR or code comments

### DIFF
--- a/HRNet.py
+++ b/HRNet.py
@@ -63,7 +63,8 @@ class BasicBlock(nn.Module):
             residual = x
         else: 
             residual = self.shortcut(x)
-        out += residual
+        # https://discuss.pytorch.org/t/runtimeerror-one-of-the-variables-needed-for-gradient-computation-has-been-modified-by-an-inplace-operation-torch-floattensor-64-1-which-is-output-0-of-asstridedbackward0-is-at-version-3-expected-version-2-instead-hint-the-backtrace-further-a/171826/7
+        out = out + residual
         out = self.relu(out)
 
         return out

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ this implementation is mainly based on [Deep Camouflage Images](http://zhangqing
 - torchvision
 - tqdm
 - albumentations
-- scikit-learn==0.23.2
+- scikit-learn
 - opencv-contrib
 </details>
 
@@ -89,17 +89,17 @@ For custom images, you should prepare
 ```
 - show_every : interval for displaying intermediate result
 - save_process : If True, save intermediate result by every `show_every`
-- show_comp : compressino ratio for display
+- show_comp : compression ratio for display
 ```
 
 ## Influence by loss function
 According to [Deep Camouflage Images](http://zhangqing-home.net/files/papers/2020/aaai2020.pdf), losses has following impact for generated image:
 
 - style loss : control similarity between generated image and background image
-- camouflage loss : control diffuculty for detection of camouflage objects in generated image
+- camouflage loss : control difficulty for detection of camouflage objects in generated image
     - leave loss : leave foreground features in generated image
     - remove loss : remove foreground features in generated image
-- reguralization loss : control consistency for generated image
+- regularization loss : control consistency for generated image
 - total variation loss : smooth generated image
 
 |style|style+cam|

--- a/camouflage_HRNet.py
+++ b/camouflage_HRNet.py
@@ -14,7 +14,9 @@ import datetime
 from sklearn.metrics.pairwise import cosine_distances,cosine_similarity
 from sklearn.manifold import LocallyLinearEmbedding
 from sklearn.neighbors import NearestNeighbors
-from sklearn.manifold.locally_linear import barycenter_kneighbors_graph
+# upgrade sklearn to latest version to avoid numpy type deprecation problem
+# new version of sklearn requires to load barycenter_kneighbors_graph from sklearn.manifold._locally_linear
+from sklearn.manifold._locally_linear import barycenter_kneighbors_graph
 
 import HRNet
 from hidden_recommend import recommend

--- a/hidden_recommend.py
+++ b/hidden_recommend.py
@@ -43,7 +43,7 @@ def HOG(img):
     # Gradient histogram
     def quantization(gradient):
         # prepare quantization table
-        gradient_quantized = np.zeros_like(gradient, dtype=np.int)
+        gradient_quantized = np.zeros_like(gradient, dtype=int) # np.int is deprecated after 1.20
 
         # quantization base
         d = np.pi / 9

--- a/params_Canyon.py
+++ b/params_Canyon.py
@@ -2,7 +2,7 @@ class CFG:
     ########################
     #### initial setting ###
     ########################
-    input_path="samples/inputs/kuma.png "
+    input_path="samples/inputs/kuma.png"
     mask_path="samples/inputs/kuma_mask.png"
     bg_path="samples/inputs/canyon.png"
     output_dir="samples/outputs/HRNet/Canyon_kuma"

--- a/params_Cliff.py
+++ b/params_Cliff.py
@@ -2,7 +2,7 @@ class CFG:
     ########################
     #### initial setting ###
     ########################
-    input_path="samples/inputs/kuma.png "
+    input_path="samples/inputs/kuma.png"
     mask_path="samples/inputs/kuma_mask.png"
     bg_path="samples/inputs/cliff.jpg"
     output_dir="samples/outputs/HRNet/Cliff_kuma"

--- a/params_CliffRiver.py
+++ b/params_CliffRiver.py
@@ -2,7 +2,7 @@ class CFG:
     ########################
     #### initial setting ###
     ########################
-    input_path="samples/inputs/kuma.png "
+    input_path="samples/inputs/kuma.png"
     mask_path="samples/inputs/kuma_mask.png"
     bg_path="samples/inputs/cliff_river.png"
     output_dir="samples/outputs/HRNet/CliffRiver_kuma"

--- a/params_Mountain.py
+++ b/params_Mountain.py
@@ -2,7 +2,7 @@ class CFG:
     ########################
     #### initial setting ###
     ########################
-    input_path="samples/inputs/kuma.png "
+    input_path="samples/inputs/kuma.png"
     mask_path="samples/inputs/kuma_mask.png"
     bg_path="samples/inputs/mountain.jpg"
     output_dir="samples/outputs/HRNet/Mountain_kuma"

--- a/params_SeaMountain.py
+++ b/params_SeaMountain.py
@@ -2,7 +2,7 @@ class CFG:
     ########################
     #### initial setting ###
     ########################
-    input_path="samples/inputs/kuma.png "
+    input_path="samples/inputs/kuma.png"
     mask_path="samples/inputs/kuma_mask.png"
     bg_path="samples/inputs/sea_mountain.jpg"
     output_dir="samples/outputs/HRNet/SeaMountain_kuma"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tqdm
 albumentations
 opencv-contrib-python
-scikit-learn==0.23.2
+scikit-learn


### PR DESCRIPTION
Using pytorch 2.0.1 and CUDA 11.8. Due to numpy type (np.int, np.float, etc...) is deprecated after numpy 1.20, and sklearn uses a lot in their code, so I upgrade the sklearn version to the latest (1.2.2), not sure if some bugs is caused by this upgrade.
1. fix some typos in README.md, and delete the version limitation of sklearn.
2. delete the version limitation of sklearn in requirements.txt.
3. since I upgrade the sklearn version, need to update 1 import line in camouflage_HRNet.py.
4. fix HRNet.py to solve runtime error: one of the variables needed for gradient computation has been modified by an inplace operation....
5. fix the file paths (the input_path) in params_*.py files.
6. fix the numpy type deprecation problem in hidden_recommend.py.